### PR TITLE
Add Language Code Parameter

### DIFF
--- a/Invoke-DHCPCheckup.ps1
+++ b/Invoke-DHCPCheckup.ps1
@@ -296,6 +296,9 @@ function Invoke-DHCPCheckup
     .PARAMETER dnsServerName
     The name of the DNS server that hosts the ADI-DNS zone in the domain
 
+    .PARAMETER LangCode
+    The language code for the Active Directory default language that is been used
+
     .EXAMPLE
     Invoke-DHCPCheckup -domainName akamai.test -dnsServerName dc2022.akamai.test
 

--- a/Invoke-DHCPCheckup.ps1
+++ b/Invoke-DHCPCheckup.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module DHCPServer
+Import-Module DHCPServer
 Import-Module ActiveDirectory
 Import-Module DnsServer
 
@@ -42,7 +42,17 @@ function GetActiveActiveDhcpServers
 
 function GetStrongUsers
 {
-    $strongGroups = ("Domain Controllers", "Domain Admins", "Enterprise Admins", "DnsAdmins", "Administrators")
+    param
+    (
+        [parameter()][ValidateSet('en','de')][String]$LangCode
+    )
+
+    switch($LangCode)
+    {
+        'en' {$strongGroups = ("Domain Controllers", "Domain Admins", "Enterprise Admins", "DnsAdmins", "Administrators")}
+        'de' {$strongGroups = ("Domänencontroller", "Domänen-Admins", "Organisations-Admins", "DnsAdmins", "Administratoren")}
+    }
+
     $strongGroupsMembers = @()
 
     foreach ($group in $strongGroups)
@@ -299,6 +309,7 @@ function Invoke-DHCPCheckup
     (
         [parameter(Mandatory=$True)][String]$domainName,
         [parameter(Mandatory=$True)][String]$dnsServerName,
+        [parameter()][ValidateSet('en','de')][String]$LangCode = 'en',
         [parameter(ValueFromRemainingArguments=$true)]$invalid_parameter
     )
 
@@ -346,7 +357,7 @@ By Ori David of Akamai SIG
 
 
     # Get a list of strong group members
-    $strongGroupMembers = GetStrongUsers
+    $strongGroupMembers = GetStrongUsers -LangCode $LangCode
 
 
     Write-Host "`n-----------------------------------------`nChecking DNS Credentials Settings`n-----------------------------------------`n"


### PR DESCRIPTION
I have added the parameter LangCode for the function "Invoke-DHCPCheckup". This parameter is used in the "GetStrongUsers" function to change the list of $strongGroups so that the name of these groups matches a specific language used in the Active Directory. I've added German to the list. English was already in the original. The default value for the parameter is 'en'.