### PR TITLE
Add a check for DHCP / DNS Dynamic Update settings

### DIFF
--- a/Invoke-DHCPCheckup.ps1
+++ b/Invoke-DHCPCheckup.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module DHCPServer
+Import-Module DHCPServer
 Import-Module ActiveDirectory
 Import-Module DnsServer
 
@@ -170,6 +170,69 @@ function Check-DhcpNameProtectionSettings
                 $printed = $True
             }
         }
+
+        if ($printed)
+        {
+            Write-Host ""
+        }
+    }
+}
+
+function Check-DhcpDynamicNameUpdateSettings
+{
+    param(
+    [parameter(Mandatory=$True)][String[]]$ActiveDhcpServers
+    )
+
+    foreach ($server in $ActiveDhcpServers)
+    {
+        $printed = $False
+        $serverDisplayName = $server.ToUpper()
+
+        # IPv4 settings
+
+        $serverV4DnsSettings = Get-DhcpServerv4DnsSetting -ComputerName $server
+
+        if ($serverV4DnsSettings.DynamicUpdates -ne "Never")
+        {
+            Write-Host "[*] $($serverDisplayName) - DNS Dynamic Updates are enabled (Value: $($serverV4DnsSettings.DynamicUpdates)) on the server level for IPv4. This means that new scopes would be created with DNS Dynamic Updates enabled too."
+            $printed = $True
+        }
+
+        $serverV4Scopes = Get-DhcpServerv4Scope -ComputerName $server
+
+        foreach ($scopeID in $serverV4Scopes)
+        {
+            $scopeV4DnsSettings = Get-DhcpServerv4DnsSetting -ComputerName $server -ScopeId $scopeID.ScopeId.IPAddressToString
+            if ($scopeV4DnsSettings.DynamicUpdates -ne "Never")
+            {
+                Write-Host "[*] $($serverDisplayName) - DNS Dynamic Updates are enabled (Value: $($scopeV4DnsSettings.DynamicUpdates)) for the IPv4 scope: $($scopeID.Name) - $($scopeID.ScopeId.IPAddressToString)"
+                $printed = $True
+            }
+        }
+
+        # IPv6 settings
+
+        $serverV6DnsSettings = Get-DhcpServerv6DnsSetting -ComputerName $server
+
+        if ($serverV6DnsSettings.DynamicUpdates -ne "Never")
+        {
+            Write-Host "[*] $($serverDisplayName) - DNS Dynamic Updates are enabled (Value: $($serverV6DnsSettings.DynamicUpdates)) on the server level for IPv6. This means that new scopes would be created with DNS Dynamic Updates enabled too."
+            $printed = $True
+        }
+
+        $serverV6Scopes = Get-DhcpServerv6Scope -ComputerName $server
+
+        foreach ($scopeID in $serverV6Scopes)
+        {
+            $scopeV6DnsSettings = Get-DhcpServerv6DnsSetting -ComputerName $server -ScopeId $scopeID.ScopeId.IPAddressToString
+            if ($scopeV6DnsSettings.DynamicUpdates -ne "Never")
+            {
+                Write-Host "[*] $($serverDisplayName) - DNS Dynamic Updates are enabled (Value: $($scopeV6DnsSettings.DynamicUpdates)) for the IPv6 scope: $($scopeID.Name) - $($scopeID.ScopeId.IPAddressToString)"
+                $printed = $True
+            }
+        }
+
 
         if ($printed)
         {
@@ -362,6 +425,11 @@ By Ori David of Akamai SIG
     Write-Host "`n-----------------------------------------`nChecking DNS Credentials Settings`n-----------------------------------------`n"
     
     $DhcpCredentials = Check-DnsCredentialSettings -ActiveDhcpServers $ActiveDhcpServers -strongGroupsMembers $strongGroupMembers
+
+
+    Write-Host "`n-----------------------------------------`nChecking DHCP DNS Dynamic Update Settings`n-----------------------------------------`n"
+    
+    Check-DhcpDynamicNameUpdateSettings -ActiveDhcpServers $ActiveDhcpServers
 
 
     Write-Host "`n-----------------------------------------`nChecking DHCP Name Protection Settings`n-----------------------------------------`n"

--- a/Invoke-DHCPCheckup.ps1
+++ b/Invoke-DHCPCheckup.ps1
@@ -184,7 +184,7 @@ function Check-DnsUpdateProxyMembership
 
     # Check for members of DNSUpdateproxy
 
-    $updateProxymembers = Get-ADGroupMember "DNSUpdateProxy"
+    $updateProxymembers = Get-ADGroupMember "DNSUpdateProxy" -Recursive
 
     foreach ($member in $updateProxymembers)
     {

--- a/Invoke-DHCPCheckup.ps1
+++ b/Invoke-DHCPCheckup.ps1
@@ -42,12 +42,19 @@ function GetActiveActiveDhcpServers
 
 function GetStrongUsers
 {
-    $strongGroups = ("Domain Controllers", "Domain Admins", "Enterprise Admins", "DnsAdmins", "Administrators")
+    $DomainSID = (Get-ADDomain).DomainSID.ToString()
+    $strongGroupsDomainControllers = $DomainSID + "-516"
+    $strongGroupsDomainAdmins = $DomainSID + "-516"
+    $strongGroupsEnterpriseAdmins = $DomainSID + "-519"
+    $strongGroupsDNSAdmins = (get-adgroup dnsadmins).sid.ToString()
+    $strongGroupsAdministrators = "S-1-5-32-544"
+    
+    $strongGroups = ($strongGroupsDomainControllers, $strongGroupsDomainAdmins, $strongGroupsEnterpriseAdmins, $strongGroupsDNSAdmins, $strongGroupsAdministrators)
     $strongGroupsMembers = @()
 
     foreach ($group in $strongGroups)
     {
-        $strongGroupsMembers += Get-ADGroupMember $group | select name
+        $strongGroupsMembers += Get-ADGroupMember $group -Recursive | select name
     }
 
     $strongGroupsMembers = $strongGroupsMembers | select name -unique 

--- a/Invoke-DHCPCheckup.ps1
+++ b/Invoke-DHCPCheckup.ps1
@@ -213,7 +213,7 @@ function Find-VulnerableDnsRecords
     $vulnerableRecords = @()
     $printed = $False
 
-    $authenticatedUsersWriteAuthenticatedUserSID = New-Object System.Security.Principal.SecurityIdentifier(“S-1-5-11“)
+    $authenticatedUsersWriteAuthenticatedUserSID = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-11")
     $authenticatedUsersWriteAuthenticatedUserUser = $authenticatedUsersWriteAuthenticatedUserSID.Translate( [System.Security.Principal.NTAccount])
     
     $DnsRecords = Get-DnsServerResourceRecord -ZoneName $domainName -ComputerName $dnsServerName

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It also requires the following Powershell modules:
 
 To run use the following commands:
 ```
-PS C:\Users\Administrator> Import-Module C:\Users\Administrator\Desktop\DHCP-Checkup.ps1
+PS C:\Users\Administrator> Import-Module C:\Users\Administrator\Desktop\Invoke-DHCPCheckup.ps1
 PS C:\Users\Administrator> Invoke-DHCPCheckup -domainName <domain_name> -dnsServerName <adidns_server_fqdn>
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ PS C:\Users\Administrator> Import-Module C:\Users\Administrator\Desktop\Invoke-D
 PS C:\Users\Administrator> Invoke-DHCPCheckup -domainName <domain_name> -dnsServerName <adidns_server_fqdn>
 ```
 
-For domains that use languages other than english as their default language, adjust the names of the strong groups at line 45 if necessary.
-
 -------
 Copyright 2023 Akamai Technologies Inc.
 


### PR DESCRIPTION
I added a check for DHCP / DNS Dynamic Update settings. 
For that I added a new function called `Check-DhcpDynamicNameUpdateSettings`. It checks the server wide option and each DHCP scope (commit b079c4a216739997607fa4c1e7a84512868d65dc).

I based my improvements on #13 by @ForumSchlampe, because their improvements for language independence make a ton of sense. But I replaced some weird quotation marks that they used in one line (`“` instead of `"`) (commit 27ce5ae88bf15a4567e178a3939d5b6e08643b11).